### PR TITLE
Update zodbupdate to work with latest Python versions, and add a conversion feature to Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+*.pyc
+.coverage*
+.installed.cfg
+.tox
+__pycache__
+bin
+develop-eggs
+htmlcov/
+lib/
+parts
+pip-selfcheck.json
+pyvenv.cfg
+src/*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy3
+install:
+    - pip install -U pip setuptools
+    - pip install -U zope.testrunner coverage coveralls
+    - pip install -U -e .[test]
+script:
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
+notifications:
+    email: false
+cache: pip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,13 @@ Changes
 0.6 (unreleased)
 ----------------
 
-- ...
+- Support Python 2.7 and 3.6.
+
+- The option to the select the pickler (``--pickler``) has been
+  removed. This was only useful if you had extension classes with
+  Python 2.5 or less.
+
+- Added an option to convert a database to Python 3.
 
 0.5 (2010-10-07)
 ----------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changes
 0.6 (unreleased)
 ----------------
 
-- Support Python 2.7 and 3.6.
+- Support Python 2.7 and 3.4, 3.5 and 3.6 and pypy 3. Drop any older
+  version of Python.
 
 - The option to the select the pickler (``--pickler``) has been
   removed. This was only useful if you had extension classes with

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include *.txt
+include *.rst
+include .coveragerc
+include bootstrap.py
+include buildout.cfg
+include versions.cfg
+include tox.ini
+include .travis.yml

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (c) 2006 Zope Corporation and Contributors.
+# Copyright (c) 2006 Zope Foundation and Contributors.
 # All Rights Reserved.
 #
 # This software is subject to the provisions of the Zope Public License,
@@ -16,62 +16,163 @@
 Simply run this script in a directory containing a buildout.cfg.
 The script accepts buildout command-line options, so you can
 use the -c option to specify an alternate configuration file.
-
-$Id: bootstrap.py 90478 2008-08-27 22:44:46Z georgyberdyshev $
 """
 
-import os, shutil, sys, tempfile, urllib2
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
 
 tmpeggs = tempfile.mkdtemp()
 
-is_jython = sys.platform.startswith('java')
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep 
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("-v", "--version", help="use a specific zc.buildout version")
+
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --version, the "
+                        "bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+
+
+options, args = parser.parse_args()
+
+######################################################################
+# load/install setuptools
 
 try:
-    import pkg_resources
+    if options.allow_site_packages:
+        import setuptools
+        import pkg_resources
+    from urllib.request import urlopen
 except ImportError:
-    ez = {}
-    exec urllib2.urlopen('http://peak.telecommunity.com/dist/ez_setup.py'
-                         ).read() in ez
-    ez['use_setuptools'](to_dir=tmpeggs, download_delay=0)
+    from urllib2 import urlopen
 
-    import pkg_resources
+ez = {}
+exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
-if sys.platform == 'win32':
-    def quote(c):
-        if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
-        else:
-            return c
-else:
-    def quote (c):
-        return c
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions 
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'. 
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
-cmd = 'from setuptools.command.easy_install import main; main()'
-ws  = pkg_resources.working_set
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
 
-if is_jython:
-    import subprocess
-    
-    assert subprocess.Popen([sys.executable] + ['-c', quote(cmd), '-mqNxd', 
-           quote(tmpeggs), 'zc.buildout'], 
-           env=dict(os.environ,
-               PYTHONPATH=
-               ws.find(pkg_resources.Requirement.parse('setuptools')).location
-               ),
-           ).wait() == 0
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
 
-else:
-    assert os.spawnle(
-        os.P_WAIT, sys.executable, quote (sys.executable),
-        '-c', quote (cmd), '-mqNxd', quote (tmpeggs), 'zc.buildout',
-        dict(os.environ,
-            PYTHONPATH=
-            ws.find(pkg_resources.Requirement.parse('setuptools')).location
-            ),
-        ) == 0
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+cmd = [sys.executable, '-c',
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+requirement = 'zc.buildout'
+version = options.version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        for part in parsed_version:
+            if (part[:1] == '*') and (part not in _final_parts):
+                return False
+        return True
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd, env=dict(os.environ, PYTHONPATH=setuptools_path)) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
 
 ws.add_entry(tmpeggs)
-ws.require('zc.buildout')
+ws.require(requirement)
 import zc.buildout.buildout
-zc.buildout.buildout.main(sys.argv[1:] + ['bootstrap'])
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
 shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,10 +1,10 @@
 [buildout]
-develop = . 
+develop = .
 parts = zodbupdate test
 
 [test]
 recipe = zc.recipe.testrunner
-eggs = zodbupdate
+eggs = zodbupdate[test]
 
 [zodbupdate]
 recipe = zc.recipe.egg

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ def read(x):
     return open(x).read()
 
 
+tests_require = [
+    'persistent',
+]
+
 setup(name='zodbupdate',
       author='Zope Developers',
       author_email='zodb-dev@zope.org',
@@ -40,6 +44,9 @@ setup(name='zodbupdate',
           'transaction',
           'zodbpickle',
       ],
+      test_suite='zodbupdate.tests.test_suite',
+      tests_require=tests_require,
+      extras_require={'test': tests_require},
       entry_points={
           "console_scripts": ['zodbupdate = zodbupdate.main:main']
       })

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ def read(x):
 
 tests_require = [
     'persistent',
+    'zope.interface',
 ]
 
 setup(name='zodbupdate',

--- a/setup.py
+++ b/setup.py
@@ -14,27 +14,30 @@
 
 from setuptools import setup, find_packages
 
-read = lambda x:open(x).read()
+
+def read(x):
+    return open(x).read()
+
 
 setup(name='zodbupdate',
       author='Zope Developers',
       author_email='zodb-dev@zope.org',
       url='http://www.python.org/pypi/zodbupdate',
       license='ZPL 2.1',
-      description=
-        'Update ZODB class references for moved or renamed classes.',
+      description='Update ZODB class references for moved or renamed classes.',
       long_description=(
         read('README.txt')
         + '\n' +
         read('CHANGES.txt')),
-      version='0.6dev',
+      version='0.6.dev0',
       package_dir={'': 'src'},
       packages=find_packages('src'),
       include_package_data=True,
       install_requires=[
-          'ZODB3',
+          'ZODB',
+          'zodbpickle',
           'setuptools'
       ],
-      entry_points = dict(
-        console_scripts =
-            ['zodbupdate = zodbupdate.main:main']))
+      entry_points={
+          "console_scripts": ['zodbupdate = zodbupdate.main:main']
+      })

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,10 @@ setup(name='zodbupdate',
       include_package_data=True,
       install_requires=[
           'ZODB',
+          'setuptools',
+          'six',
+          'transaction',
           'zodbpickle',
-          'setuptools'
       ],
       entry_points={
           "console_scripts": ['zodbupdate = zodbupdate.main:main']

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -1,0 +1,48 @@
+
+import datetime
+import zodbpickle
+
+
+class Py3Datetime(datetime.datetime):
+
+    def __reduce__(self):
+        type_info, args = super(Py3Datetime, self).__reduce__()
+        assert len(args) == 1
+        return (datetime.datetime, (zodbpickle.binary(args[0]),))
+
+    def __reduce_ex__(self, protocol):
+        type_info, args = super(Py3Datetime, self).__reduce_ex__(protocol)
+        assert len(args) == 1
+        return (datetime.datetime, (zodbpickle.binary(args[0]),))
+
+
+class Py3Date(datetime.date):
+
+    def __reduce__(self):
+        type_info, args = super(Py3Date, self).__reduce__()
+        assert len(args) == 1
+        return (datetime.date, (zodbpickle.binary(args[0]),))
+
+    def __reduce_ex__(self, protocol):
+        type_info, args = super(Py3Date, self).__reduce_ex__(protocol)
+        assert len(args) == 1
+        return (datetime.date, (zodbpickle.binary(args[0]),))
+
+
+class Py3Time(datetime.time):
+
+    def __reduce__(self):
+        type_info, args = super(Py3Time, self).__reduce__()
+        assert len(args) == 1
+        return (datetime.time, (zodbpickle.binary(args[0]),))
+
+    def __reduce_ex__(self, protocol):
+        type_info, args = super(Py3Time, self).__reduce_ex__(protocol)
+        assert len(args) == 1
+        return (datetime.time, (zodbpickle.binary(args[0]),))
+
+
+CONVERT_RENAMES = {
+    'datetime datetime': 'zodbupdate.convert Py3Datetime',
+    'datetime date': 'zodbupdate.convert Py3Date',
+    'datetime time': 'zodbupdate.convert Py3Time'}

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -3,46 +3,46 @@ import datetime
 import zodbpickle
 
 
-class Py3Datetime(datetime.datetime):
+class Datetime(datetime.datetime):
 
     def __reduce__(self):
-        type_info, args = super(Py3Datetime, self).__reduce__()
-        assert len(args) == 1
-        return (datetime.datetime, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Datetime, self).__reduce__()
+        assert len(args) > 0
+        return (datetime.datetime, (zodbpickle.binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
-        type_info, args = super(Py3Datetime, self).__reduce_ex__(protocol)
-        assert len(args) == 1
-        return (datetime.datetime, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Datetime, self).__reduce_ex__(protocol)
+        assert len(args) > 0
+        return (datetime.datetime, (zodbpickle.binary(args[0]),) + args[1:])
 
 
-class Py3Date(datetime.date):
+class Date(datetime.date):
 
     def __reduce__(self):
-        type_info, args = super(Py3Date, self).__reduce__()
-        assert len(args) == 1
-        return (datetime.date, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Date, self).__reduce__()
+        assert len(args) > 0
+        return (datetime.date, (zodbpickle.binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
-        type_info, args = super(Py3Date, self).__reduce_ex__(protocol)
-        assert len(args) == 1
-        return (datetime.date, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Date, self).__reduce_ex__(protocol)
+        assert len(args) > 0
+        return (datetime.date, (zodbpickle.binary(args[0]),) + args[1:])
 
 
-class Py3Time(datetime.time):
+class Time(datetime.time):
 
     def __reduce__(self):
-        type_info, args = super(Py3Time, self).__reduce__()
-        assert len(args) == 1
-        return (datetime.time, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Time, self).__reduce__()
+        assert len(args) > 0
+        return (datetime.time, (zodbpickle.binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
-        type_info, args = super(Py3Time, self).__reduce_ex__(protocol)
-        assert len(args) == 1
-        return (datetime.time, (zodbpickle.binary(args[0]),))
+        type_info, args = super(Time, self).__reduce_ex__(protocol)
+        assert len(args) > 0
+        return (datetime.time, (zodbpickle.binary(args[0]),) + args[1:])
 
 
 CONVERT_RENAMES = {
-    'datetime datetime': 'zodbupdate.convert Py3Datetime',
-    'datetime date': 'zodbupdate.convert Py3Date',
-    'datetime time': 'zodbupdate.convert Py3Time'}
+    'datetime datetime': 'zodbupdate.convert Datetime',
+    'datetime date': 'zodbupdate.convert Date',
+    'datetime time': 'zodbupdate.convert Time'}

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -49,7 +49,6 @@ class Time(datetime.time):
 
 def default_renames():
     return {
-        ('copy_reg', '_reconstructor'): ('copyreg', '_reconstructor'),
         ('datetime', 'datetime'): ('zodbupdate.convert', 'Datetime'),
         ('datetime', 'date'): ('zodbupdate.convert', 'Date'),
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -49,6 +49,7 @@ class Time(datetime.time):
 
 def default_renames():
     return {
+        ('copy_reg', '_reconstructor'): ('copyreg', '_reconstructor'),
         ('datetime', 'datetime'): ('zodbupdate.convert', 'Datetime'),
         ('datetime', 'date'): ('zodbupdate.convert', 'Date'),
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -1,6 +1,11 @@
-
+import logging
+import six
 import datetime
 import zodbpickle
+import pkg_resources
+
+
+logger = logging.getLogger('zodbupdate')
 
 
 class Datetime(datetime.datetime):
@@ -42,7 +47,60 @@ class Time(datetime.time):
         return (datetime.time, (zodbpickle.binary(args[0]),) + args[1:])
 
 
-CONVERT_RENAMES = {
-    'datetime datetime': 'zodbupdate.convert Datetime',
-    'datetime date': 'zodbupdate.convert Date',
-    'datetime time': 'zodbupdate.convert Time'}
+def default_renames():
+    return {
+        ('datetime', 'datetime'): ('zodbupdate.convert', 'Datetime'),
+        ('datetime', 'date'): ('zodbupdate.convert', 'Date'),
+        ('datetime', 'time'): ('zodbupdate.convert', 'Time')}
+
+
+def decode_attribute(attribute, encoding):
+
+    def decode(data):
+        value = data.get(attribute)
+        if not isinstance(value, six.text_type):
+            data[attribute] = value.decode(encoding)
+            return True
+        return False
+
+    return decode
+
+
+def encode_binary(attribute):
+
+    def encode(data):
+        value = data.get(attribute)
+        if not isinstance(value, zodbpickle.binary):
+            data[attribute] = zodbpickle.binary(value)
+            return True
+        return False
+
+    return encode
+
+
+def load_decoders():
+    decoders = {}
+    for entry_point in pkg_resources.iter_entry_points('zodbupdate.decode'):
+        definition = entry_point.load()
+        for attribute_path, encoding in definition.items():
+            module, cls, attribute = attribute_path.split(' ')
+            if encoding == 'binary':
+                decoders.setdefault((module, cls), []).append(
+                    encode_binary(attribute))
+            else:
+                decoders.setdefault((module, cls), []).append(
+                    decode_attribute(attribute, encoding))
+        logger.info('Loaded {} decode rules from {}:{}'.format(
+            len(definition), entry_point.module_name, entry_point.name))
+    return decoders
+
+
+def update_magic_data_fs(filename):
+    if not filename:
+        logger.info("We do not know the database file so "
+                    "we do not change the magic marker.")
+    else:
+        logger.info("Updating magic marker for {}".format(filename))
+        with open(filename, 'r+b') as data_fs:
+            # Override the magic.
+            data_fs.write('FS30')

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -124,9 +124,9 @@ def main():
 
     try:
         updater()
-    except Exception as e:
-        logging.debug('An error occured', exc_info=True)
-        logging.error('Stopped processing, due to: %s' % e)
+    except Exception as error:
+        logging.error('An error occured', exc_info=True)
+        logging.error('Stopped processing, due to: {}'.format(error))
         raise SystemExit()
 
     implicit_renames = updater.processor.get_found_implicit_rules()

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -67,7 +67,7 @@ parser.add_option(
 class DuplicateFilter(object):
 
     def __init__(self):
-        self.seen = set()
+        self.reset()
 
     def filter(self, record):
         if record.msg in self.seen:
@@ -75,21 +75,26 @@ class DuplicateFilter(object):
         self.seen.add(record.msg)
         return True
 
+    def reset(self):
+        self.seen = set()
+
 
 duplicate_filter = DuplicateFilter()
 
 
-def setup_logger(verbose=False, quiet=False):
+def setup_logger(verbose=False, quiet=False, handler=None):
+    logging.getLogger('zodbupdate.serialize').addFilter(duplicate_filter)
     if quiet:
         level = logging.ERROR
     elif verbose:
         level = logging.DEBUG
     else:
         level = logging.INFO
-
-    logging.getLogger().addHandler(logging.StreamHandler())
-    logging.getLogger().setLevel(level)
-    logger.addFilter(duplicate_filter)
+    if handler is None:
+        handler = logging.StreamHandler()
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    logger.addHandler(handler)
     return logger
 
 

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -19,14 +19,14 @@ import logging
 import optparse
 import pkg_resources
 import pprint
-import sys
 import time
 import zodbupdate.update
 import zodbupdate.utils
 
 
 parser = optparse.OptionParser(
-    description="Updates all references to classes to their canonical location.")
+    description=("Updates all references to classes to "
+                 "their canonical location."))
 parser.add_option(
     "-f", "--file",
     help="load FileStorage")
@@ -52,12 +52,9 @@ parser.add_option(
     "-d", "--debug", action="store_true",
     help="post mortem pdb on failure")
 parser.add_option(
-    "-p", "--pickler", default="C",
-    help="chooser unpickler implementation C or Python (default C)")
-parser.add_option(
     "--pack", action="store_true", dest="pack",
-    help="pack the storage when done. use in conjunction of -c if you have blobs storage")
-
+    help=("pack the storage when done. use in conjunction of -c "
+          "if you have blobs storage"))
 
 
 class DuplicateFilter(object):
@@ -71,15 +68,12 @@ class DuplicateFilter(object):
         self.seen.add(record.msg)
         return True
 
+
 duplicate_filter = DuplicateFilter()
 
 
 def main():
     options, args = parser.parse_args()
-
-    if options.pickler not in zodbupdate.utils.UNPICKLERS:
-        raise SystemExit('Invalid pickler chosen. Available picklers: %s' %
-                         ', '.join(zodbupdate.utils.UNPICKLERS))
 
     if options.quiet:
         level = logging.ERROR
@@ -112,16 +106,16 @@ def main():
     for entry_point in pkg_resources.iter_entry_points('zodbupdate'):
         rules = entry_point.load()
         rename_rules.update(rules)
-        logging.info('Loaded %s rules from %s:%s' %
-                      (len(rules), entry_point.module_name, entry_point.name))
+        logging.info(
+            'Loaded %s rules from %s:%s' %
+            (len(rules), entry_point.module_name, entry_point.name))
 
     updater = zodbupdate.update.Updater(
         storage,
         dry=options.dry_run,
         renames=rename_rules,
         start_at=start_at,
-        debug=options.debug,
-        pickler_name=options.pickler)
+        debug=options.debug)
 
     try:
         updater()
@@ -144,4 +138,3 @@ def main():
         print('Packing storage ...')
         storage.pack(time.time(), ZODB.serialize.referencesf)
     storage.close()
-

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -79,6 +79,20 @@ class DuplicateFilter(object):
 duplicate_filter = DuplicateFilter()
 
 
+def setup_logger(verbose=False, quiet=False):
+    if quiet:
+        level = logging.ERROR
+    elif verbose:
+        level = logging.DEBUG
+    else:
+        level = logging.INFO
+
+    logging.getLogger().addHandler(logging.StreamHandler())
+    logging.getLogger().setLevel(level)
+    logger.addFilter(duplicate_filter)
+    return logger
+
+
 def load_renames():
     renames = {}
     for entry_point in pkg_resources.iter_entry_points('zodbupdate'):
@@ -142,16 +156,7 @@ def format_renames(renames):
 def main():
     options, args = parser.parse_args()
 
-    if options.quiet:
-        level = logging.ERROR
-    elif options.verbose:
-        level = logging.DEBUG
-    else:
-        level = logging.INFO
-
-    logging.getLogger().addHandler(logging.StreamHandler())
-    logging.getLogger().setLevel(level)
-    logger.addFilter(duplicate_filter)
+    setup_logger(quiet=options.quiet, verbose=options.verbose)
 
     if options.file and options.config:
         raise AssertionError(

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -124,14 +124,14 @@ def create_updater(
     repickle_all = False
     pickle_protocol = zodbupdate.utils.DEFAULT_PROTOCOL
     if convert_py3:
-        pickle_protocol = 3
-        repickle_all = True
-        decoders.update(zodbupdate.convert.load_decoders())
-        renames.update(zodbupdate.convert.default_renames())
         if six.PY3:
             raise AssertionError(
                 'You can only convert a database to Python 3 format '
                 'from Python 2.')
+        pickle_protocol = 3
+        repickle_all = True
+        decoders.update(zodbupdate.convert.load_decoders())
+        renames.update(zodbupdate.convert.default_renames())
 
     return zodbupdate.update.Updater(
         storage,

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -78,7 +78,7 @@ def main():
     options, args = parser.parse_args()
 
     if options.pickler not in zodbupdate.utils.UNPICKLERS:
-        raise SystemExit(u'Invalid pickler chosen. Available picklers: %s' %
+        raise SystemExit('Invalid pickler chosen. Available picklers: %s' %
                          ', '.join(zodbupdate.utils.UNPICKLERS))
 
     if options.quiet:
@@ -94,7 +94,7 @@ def main():
 
     if options.file and options.config:
         raise SystemExit(
-            u'Exactly one of --file or --config must be given.')
+            'Exactly one of --file or --config must be given.')
 
     if options.file:
         storage = ZODB.FileStorage.FileStorage(options.file)
@@ -102,7 +102,7 @@ def main():
         storage = ZODB.config.storageFromURL(options.config)
     else:
         raise SystemExit(
-            u'Exactly one of --file or --config must be given.')
+            'Exactly one of --file or --config must be given.')
 
     start_at = '0x00'
     if options.oid:
@@ -112,7 +112,7 @@ def main():
     for entry_point in pkg_resources.iter_entry_points('zodbupdate'):
         rules = entry_point.load()
         rename_rules.update(rules)
-        logging.info(u'Loaded %s rules from %s:%s' %
+        logging.info('Loaded %s rules from %s:%s' %
                       (len(rules), entry_point.module_name, entry_point.name))
 
     updater = zodbupdate.update.Updater(
@@ -125,23 +125,23 @@ def main():
 
     try:
         updater()
-    except Exception, e:
-        logging.debug(u'An error occured', exc_info=True)
-        logging.error(u'Stopped processing, due to: %s' % e)
+    except Exception as e:
+        logging.debug('An error occured', exc_info=True)
+        logging.error('Stopped processing, due to: %s' % e)
         raise SystemExit()
 
     implicit_renames = updater.processor.get_found_implicit_rules()
     if implicit_renames:
-        print 'Found new rules:'
-        print pprint.pformat(implicit_renames)
+        print('Found new rules:')
+        print(pprint.pformat(implicit_renames))
     if options.save_renames:
-        print 'Saving rules into %s' % options.save_renames
+        print('Saving rules into %s' % options.save_renames)
         rename_rules.update(implicit_renames)
         f = open(options.save_renames, 'w')
         f.write('renames = %s' % pprint.pformat(rename_rules))
         f.close()
     if options.pack:
-        print 'Packing storage ...'
+        print('Packing storage ...')
         storage.pack(time.time(), ZODB.serialize.referencesf)
     storage.close()
 

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -22,7 +22,7 @@ import zodbpickle
 from ZODB.broken import find_global, Broken, rebuild
 from zodbupdate import utils
 
-logger = logging.getLogger('zodbupdate')
+logger = logging.getLogger('zodbupdate.serialize')
 known_broken_modules = {}
 
 

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -84,15 +84,15 @@ class BrokenModuleFinder(object):
 sys.meta_path.append(BrokenModuleFinder())
 
 
-class NullIterator(object):
+class NullIterator(six.Iterator):
     """An empty iterator that doesn't gives any result.
     """
 
     def __iter__(self):
         return self
 
-    def next(self):
-        raise StopIteration
+    def __next__(self):
+        raise StopIteration()
 
 
 class IterableClass(type):
@@ -105,12 +105,12 @@ class IterableClass(type):
         return NullIterator()
 
 
+@six.add_metaclass(IterableClass)
 class ZODBBroken(Broken):
     """Extend ZODB Broken to work with broken objects that doesn't
     have any __Broken_newargs__ sets (which happens if their __new__
     method is not called).
     """
-    __metaclass__ = IterableClass
 
     def __reduce__(self):
         """We pickle broken objects in hope of being able to fix them later.

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -13,7 +13,7 @@
 ##############################################################################
 
 import cPickle
-import cStringIO
+import io
 import logging
 import types
 import sys
@@ -165,14 +165,14 @@ class ObjectRenamer(object):
             symb = find_global(*symb_info, Broken=ZODBBroken)
             if is_broken(symb):
                 logger.warning(
-                    u'Warning: Missing factory for %s' % u' '.join(symb_info))
+                    'Warning: Missing factory for %s' % ' '.join(symb_info))
                 create_broken_module_for(symb)
             elif hasattr(symb, '__name__') and hasattr(symb, '__module__'):
                 new_symb_info = (symb.__module__, symb.__name__)
                 if new_symb_info != symb_info:
                     logger.info(
-                        u'New implicit rule detected %s to %s' %
-                        (u' '.join(symb_info), u' '.join(new_symb_info)))
+                        'New implicit rule detected %s to %s' %
+                        (' '.join(symb_info), ' '.join(new_symb_info)))
                     self.__changes[symb_info] = new_symb_info
                     self.__added[symb_info] = new_symb_info
                     self.__changed = True
@@ -239,7 +239,7 @@ class ObjectRenamer(object):
             if is_broken(symb):
                 symb_info = (symb.__module__, symb.__name__)
                 logger.warning(
-                    u'Warning: Missing factory for %s' % u' '.join(symb_info))
+                    'Warning: Missing factory for %s' % ' '.join(symb_info))
                 return (symb_info, args)
             elif isinstance(symb, tuple):
                 return self.__update_symb(symb), args
@@ -264,12 +264,12 @@ class ObjectRenamer(object):
                  unpickler.need_repickle())):
             return None
 
-        output_file = cStringIO.StringIO()
+        output_file = io.BytesIO()
         pickler = self.__pickler(output_file)
         try:
             pickler.dump(class_meta)
             pickler.dump(data)
-        except cPickle.PicklingError, error:
+        except cPickle.PicklingError as error:
             logger.error('Error: cannot pickling modified record: %s' % error)
             # Could not pickle that record, skip it.
             return None

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -29,7 +29,7 @@ known_broken_modules = {}
 def is_broken(symb):
     """Return true if the given symbol is broken.
     """
-    return isinstance(symb, types.TypeType) and Broken in symb.__mro__
+    return isinstance(symb, six.class_types) and Broken in symb.__mro__
 
 
 def create_broken_module_for(symb):

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -26,12 +26,6 @@ logger = logging.getLogger('zodbupdate')
 known_broken_modules = {}
 
 
-def is_broken(symb):
-    """Return true if the given symbol is broken.
-    """
-    return isinstance(symb, six.class_types) and Broken in symb.__mro__
-
-
 def create_broken_module_for(symb):
     """If your pickle refer a broken class (not an instance of it, a
        reference to the class symbol itself) you have no choice than
@@ -123,7 +117,7 @@ class ZODBBroken(Broken):
         """
         return (rebuild,
                 ((self.__class__.__module__, self.__class__.__name__)
-                 + getattr(self, '__Broken_newargs__', ())),
+                 + getattr(self, '__Broken_newargs__', tuple())),
                 self.__Broken_state__)
 
 
@@ -166,7 +160,7 @@ class ObjectRenamer(object):
             return self.__renames[symb_info]
         else:
             symb = find_global(*symb_info, Broken=ZODBBroken)
-            if is_broken(symb):
+            if utils.is_broken(symb):
                 logger.warning('Warning: Missing factory for {}'.format(
                     ' '.join(symb_info)))
                 create_broken_module_for(symb)
@@ -262,7 +256,7 @@ class ObjectRenamer(object):
         """
         if isinstance(class_meta, tuple):
             symb, args = class_meta
-            if is_broken(symb):
+            if utils.is_broken(symb):
                 symb_info = (symb.__module__, symb.__name__)
                 logger.warning(
                     'Warning: Missing factory for {}'.format(

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -144,13 +144,12 @@ class ObjectRenamer(object):
     - in class information (first pickle of the record).
     """
 
-    def __init__(self, changes, pickler_name='C'):
+    def __init__(self, changes):
         self.__added = dict()
         self.__changes = dict()
         for old, new in changes.iteritems():
             self.__changes[tuple(old.split(' '))] = tuple(new.split(' '))
         self.__changed = False
-        self.__pickler_name = pickler_name
 
     def __update_symb(self, symb_info):
         """This method look in a klass or symbol have been renamed or
@@ -211,8 +210,10 @@ class ObjectRenamer(object):
         """Create an unpickler with our custom global symbol loader
         and reference resolver.
         """
-        return utils.UNPICKLERS[self.__pickler_name](
-            input_file, self.__persistent_load, self.__find_global)
+        return utils.Unpickler(
+            input_file,
+            self.__persistent_load,
+            self.__find_global)
 
     def __persistent_id(self, obj):
         """Save the given object as a reference only if it was a
@@ -226,9 +227,7 @@ class ObjectRenamer(object):
         """Create a pickler able to save to the given file, objects we
         loaded while paying attention to any reference we loaded.
         """
-        pickler = cPickle.Pickler(output_file, 1)
-        pickler.persistent_id = self.__persistent_id
-        return pickler
+        return utils.Pickler(output_file, self.__persistent_id)
 
     def __update_class_meta(self, class_meta):
         """Update class information, which can contain information

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -128,8 +128,9 @@ class ZODBUpdateTests(unittest.TestCase):
 
         updater = self.update()
 
-        self.assertEqual('cmodule1\nNewFactory\nq\x01.}q\x02.',
-                          self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertEqual(
+            '\x80\x02cmodule1\nNewFactory\nq\x01.\x80\x02}q\x02.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
         self.assertEqual('module1', self.root['test'].__class__.__module__)
         self.assertEqual('NewFactory', self.root['test'].__class__.__name__)
         renames = updater.processor.get_found_implicit_rules()
@@ -153,7 +154,7 @@ class ZODBUpdateTests(unittest.TestCase):
 
         updater = self.update(dry=False)
         self.assertEqual(
-            'cmodule1\nNewFactory\nq\x01.}q\x02.',
+            '\x80\x02cmodule1\nNewFactory\nq\x01.\x80\x02}q\x02.',
             self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
         self.assertEqual({'module1 Factory': 'module1 NewFactory'}, renames)
@@ -214,8 +215,9 @@ class ZODBUpdateTests(unittest.TestCase):
         updater = self.update(
             renames={'module1 Factory': 'module2 OtherFactory'})
 
-        self.assertEqual('cmodule2\nOtherFactory\nq\x01.}q\x02.',
-                          self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertEqual(
+            '\x80\x02cmodule2\nOtherFactory\nq\x01.\x80\x02}q\x02.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
         self.assertEqual({}, renames)
 
@@ -230,8 +232,9 @@ class ZODBUpdateTests(unittest.TestCase):
         updater = self.update(
             renames={'module1 Factory': 'module2 OtherFactory'})
 
-        self.assertEqual('cmodule2\nOtherFactory\nq\x01.}q\x02.',
-                          self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertEqual(
+            '\x80\x02cmodule2\nOtherFactory\nq\x01.\x80\x02}q\x02.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
         self.assertEqual({}, renames)
 

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -103,17 +103,17 @@ class ZODBUpdateTests(unittest.TestCase):
 
         updater = self.update()
 
-        self.assertEquals(
+        self.assertEqual(
             '\x80\x02cmodule1\nFactory\nq\x01.\x80\x02}q\x02.',
             self.storage.load(self.root['test']._p_oid, '')[0])
         self.assertTrue(
             isinstance(self.root['test'], ZODB.broken.PersistentBroken))
-        self.failUnless(len(self.log_messages))
-        self.assertEquals(
+        self.assertTrue(len(self.log_messages))
+        self.assertEqual(
             'Warning: Missing factory for module1 Factory',
             self.log_messages[0])
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({}, renames)
+        self.assertEqual({}, renames)
 
     def test_factory_renamed(self):
         # Create a ZODB with an object referencing a factory, then
@@ -128,12 +128,12 @@ class ZODBUpdateTests(unittest.TestCase):
 
         updater = self.update()
 
-        self.assertEquals('cmodule1\nNewFactory\nq\x01.}q\x02.',
+        self.assertEqual('cmodule1\nNewFactory\nq\x01.}q\x02.',
                           self.storage.load(self.root['test']._p_oid, '')[0])
-        self.assertEquals('module1', self.root['test'].__class__.__module__)
-        self.assertEquals('NewFactory', self.root['test'].__class__.__name__)
+        self.assertEqual('module1', self.root['test'].__class__.__module__)
+        self.assertEqual('NewFactory', self.root['test'].__class__.__name__)
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({'module1 Factory': 'module1 NewFactory'}, renames)
+        self.assertEqual({'module1 Factory': 'module1 NewFactory'}, renames)
 
     def test_factory_renamed_dryrun(self):
         # Run an update with "dy run" option and see that the pickle is
@@ -145,18 +145,18 @@ class ZODBUpdateTests(unittest.TestCase):
         sys.modules['module1'].NewFactory.__name__ = 'NewFactory'
 
         updater = self.update(dry=True)
-        self.assertEquals(
+        self.assertEqual(
             '\x80\x02cmodule1\nFactory\nq\x01.\x80\x02}q\x02.',
             self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({'module1 Factory': 'module1 NewFactory'}, renames)
+        self.assertEqual({'module1 Factory': 'module1 NewFactory'}, renames)
 
         updater = self.update(dry=False)
-        self.assertEquals(
+        self.assertEqual(
             'cmodule1\nNewFactory\nq\x01.}q\x02.',
             self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({'module1 Factory': 'module1 NewFactory'}, renames)
+        self.assertEqual({'module1 Factory': 'module1 NewFactory'}, renames)
 
     def test_factory_registered_with_copy_reg(self):
         # Factories registered with copy_reg.pickle loose their __name__.
@@ -185,21 +185,21 @@ class ZODBUpdateTests(unittest.TestCase):
 
         updater = self.update()
 
-        self.assertEquals('module1', self.root['test'].__class__.__module__)
-        self.assertEquals(
+        self.assertEqual('module1', self.root['test'].__class__.__module__)
+        self.assertEqual(
             'AnonymousFactory',
             self.root['test'].__class__.__name__)
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({}, renames)
+        self.assertEqual({}, renames)
 
     def test_no_transaction_if_no_changes(self):
         # If an update run doesn't produce any changes it won't commit the
         # transaction to avoid superfluous clutter in the DB.
         last = self.storage.lastTransaction()
         updater = self.update()
-        self.assertEquals(last, self.storage.lastTransaction())
+        self.assertEqual(last, self.storage.lastTransaction())
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({}, renames)
+        self.assertEqual({}, renames)
 
     def test_loaded_renames_override_automatic(self):
         # Same as test_factory_renamed, but provide a pre-defined rename
@@ -214,10 +214,10 @@ class ZODBUpdateTests(unittest.TestCase):
         updater = self.update(
             renames={'module1 Factory': 'module2 OtherFactory'})
 
-        self.assertEquals('cmodule2\nOtherFactory\nq\x01.}q\x02.',
+        self.assertEqual('cmodule2\nOtherFactory\nq\x01.}q\x02.',
                           self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({}, renames)
+        self.assertEqual({}, renames)
 
     def test_loaded_renames_override_missing(self):
         # Same as test_factory_missing, but provide a pre-defined rename
@@ -230,10 +230,10 @@ class ZODBUpdateTests(unittest.TestCase):
         updater = self.update(
             renames={'module1 Factory': 'module2 OtherFactory'})
 
-        self.assertEquals('cmodule2\nOtherFactory\nq\x01.}q\x02.',
+        self.assertEqual('cmodule2\nOtherFactory\nq\x01.}q\x02.',
                           self.storage.load(self.root['test']._p_oid, '')[0])
         renames = updater.processor.get_found_implicit_rules()
-        self.assertEquals({}, renames)
+        self.assertEqual({}, renames)
 
 
 def test_suite():

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -94,6 +94,24 @@ class ZODBUpdateTests(unittest.TestCase):
         os.unlink(self.dbfile + '.tmp')
         os.unlink(self.dbfile + '.lock')
 
+    def test_convert_datetime_to_py3(self):
+        import datetime
+
+        test = sys.modules['module1'].Factory()
+        test.date_of_birth = datetime.datetime(2018, 12, 12)
+        self.root['test'] = test
+        transaction.commit()
+
+        self.update(convert_py3=True)
+
+        # Protocol is 3 (x80x03) now and datetime payload is encoded
+        # as bytes (C).
+        self.assertEqual(
+            '\x80\x03cmodule1\nFactory\nq\x01.'
+            '\x80\x03}q\x02U\rdate_of_birthq\x03cdatetime\ndatetime\nq\x04'
+            'C\n\x07\xe2\x0c\x0c\x00\x00\x00\x00\x00\x00\x85Rq\x05s.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
+
     def test_factory_ignore_missing(self):
         # Create a ZODB with an object referencing a factory, then
         # remove the factory and update the ZODB.

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -328,6 +328,25 @@ class Python2Tests(Tests):
         renames = updater.processor.get_rules(implicit=True)
         self.assertEqual({}, renames)
 
+    def test_factory_ignore_missing_class(self):
+        factory = self.root['test'] = sys.modules['module2'].OtherFactory()
+        factory.data = sys.modules['module1'].Data
+        transaction.commit()
+        del sys.modules['module1']
+
+        updater = self.update()
+
+        self.assertEqual(
+            '\x80\x02cmodule2\nOtherFactory\nq\x01.'
+            '\x80\x02}q\x02U\x04dataq\x03cmodule1\nData\nq\x04s.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertTrue(len(self.log_messages))
+        self.assertEqual(
+            'Warning: Missing factory for module1 Data',
+            self.log_messages[0])
+        renames = updater.processor.get_rules(implicit=True)
+        self.assertEqual({}, renames)
+
     def test_factory_ignore_missing_interface(self):
         factory = self.root['test'] = sys.modules['module1'].Factory()
         zope.interface.alsoProvides(factory, sys.modules['module1'].IFactory)
@@ -508,6 +527,25 @@ class Python3Tests(Tests):
             b'\x80\x03cmodule1\nFactory\nq\x00.'
             b'\x80\x03}q\x01X\x04\x00\x00\x00dataq\x02'
             b'cmodule1\nData\nq\x03)\x81q\x04s.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertTrue(len(self.log_messages))
+        self.assertEqual(
+            'Warning: Missing factory for module1 Data',
+            self.log_messages[0])
+        renames = updater.processor.get_rules(implicit=True)
+        self.assertEqual({}, renames)
+
+    def test_factory_ignore_missing_class(self):
+        factory = self.root['test'] = sys.modules['module2'].OtherFactory()
+        factory.data = sys.modules['module1'].Data
+        transaction.commit()
+        del sys.modules['module1']
+
+        updater = self.update()
+
+        self.assertEqual(
+            b'\x80\x03cmodule2\nOtherFactory\nq\x00.'
+            b'\x80\x03}q\x01X\x04\x00\x00\x00dataq\x02cmodule1\nData\nq\x03s.',
             self.storage.load(self.root['test']._p_oid, '')[0])
         self.assertTrue(len(self.log_messages))
         self.assertEqual(

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -21,7 +21,9 @@ import ZODB.utils
 import io
 import logging
 import transaction
+import zodbupdate.convert
 import zodbupdate.serialize
+import zodbupdate.utils
 
 logger = logging.getLogger('zodbupdate')
 
@@ -32,10 +34,20 @@ class Updater(object):
     """Update class references for all current objects in a storage."""
 
     def __init__(self, storage, dry=False, renames=None,
-                 start_at='0x00', debug=False):
+                 start_at='0x00', debug=False, convert_py3=False):
+
+        all_renames = {}
+        if renames is not None:
+            all_renames.update(renames)
+        protocol = zodbupdate.utils.DEFAULT_PROTOCOL
+        if convert_py3 and protocol != 3:
+            protocol = 3
+            all_renames.update(zodbupdate.convert.CONVERT_RENAMES)
+
         self.dry = dry
         self.storage = storage
-        self.processor = zodbupdate.serialize.ObjectRenamer(renames or {})
+        self.processor = zodbupdate.serialize.ObjectRenamer(
+            all_renames, protocol)
         self.start_at = start_at
         self.debug = debug
 

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -40,14 +40,14 @@ class Updater(object):
         if renames is not None:
             all_renames.update(renames)
         protocol = zodbupdate.utils.DEFAULT_PROTOCOL
-        if convert_py3 and protocol != 3:
+        if convert_py3:
             protocol = 3
             all_renames.update(zodbupdate.convert.CONVERT_RENAMES)
 
         self.dry = dry
         self.storage = storage
         self.processor = zodbupdate.serialize.ObjectRenamer(
-            all_renames, protocol)
+            changes=all_renames, protocol=protocol, repickle_all=convert_py3)
         self.start_at = start_at
         self.debug = debug
 
@@ -89,15 +89,15 @@ class Updater(object):
                     t = self.__new_transaction()
 
             self.__commit_transaction(t, count != 0)
-        except Exception as e:
+        except Exception as error:
             if not self.debug:
-                raise e
+                raise error
             import sys
             import pdb
             (type, value, traceback) = sys.exc_info()
             pdb.post_mortem(traceback)
             del traceback
-            raise e
+            raise error
 
     @property
     def records(self):

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -18,6 +18,7 @@ from struct import pack, unpack
 import ZODB.POSException
 import ZODB.broken
 import ZODB.utils
+import six
 import io
 import logging
 import transaction
@@ -50,7 +51,7 @@ class Updater(object):
     def __new_transaction(self):
         t = transaction.Transaction()
         self.storage.tpc_begin(t)
-        t.note('Updated factory references using `zodbupdate`.')
+        t.note(six.u('Updated factory references using `zodbupdate`.'))
         return t
 
     def __commit_transaction(self, t, changed, commit_count):

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -32,11 +32,10 @@ class Updater(object):
     """Update class references for all current objects in a storage."""
 
     def __init__(self, storage, dry=False, renames=None,
-                 start_at='0x00', debug=False, pickler_name='C'):
+                 start_at='0x00', debug=False):
         self.dry = dry
         self.storage = storage
-        self.processor = zodbupdate.serialize.ObjectRenamer(
-            renames or {}, pickler_name)
+        self.processor = zodbupdate.serialize.ObjectRenamer(renames or {})
         self.start_at = start_at
         self.debug = debug
 

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -12,58 +12,44 @@
 #
 ##############################################################################
 
-import pickle
-import cPickle
+import ZODB._compat
 import logging
+import six
+
+
+if six.PY3:
+    raise RuntimeError('Not yet')
+else:
+    try:
+        import zodbpickle.fastpickle as pickle
+    except ImportError:
+        import zodbpickle.pickle as pickle
+
 
 logger = logging.getLogger('zodbupdate')
 
-
-class PythonUnpickler(pickle.Unpickler):
-    """Use Python unpickler.
-    """
-    dispatch = pickle.Unpickler.dispatch.copy()
-
-    def __init__(self, input_file, persistent_load, find_global):
-        pickle.Unpickler.__init__(self, input_file)
-        self.__repickle = False
-        self.persistent_load = persistent_load
-        self.find_class = find_global
-
-    def load_reduce(self):
-        stack = self.stack
-        args = stack.pop()
-        func = stack[-1]
-        if args is None:
-            # Hack for old ExtensionClass that was removed from Python
-            # in 2.6. We set repickle to True to trigger a repickling
-            # of this pickle later on to get ride of those records.
-            value = func.__new__(func)
-            self.__repickle = True
-            logger.warning(
-                'Warning: Pickle contains ExtensionClass hack for %s' % func)
-        else:
-            value = func(*args)
-        stack[-1] = value
-
-    def need_repickle(self):
-        """Tell the user if it is necessary to repickle the pickle to
-        update it.
-        """
-        return self.__repickle
-
-    dispatch[pickle.REDUCE] = load_reduce
+DEFAULT_PROTOCOL = ZODB._compat._protocol
 
 
-def CUnpickler(input_file, persistent_load, find_global):
-    """Use C unpickler.
-    """
-    unpickler = cPickle.Unpickler(input_file)
+def Unpickler(
+        input_file, persistent_load, find_global):
+    # Please refer to ZODB._compat for explanation.
+    unpickler = pickle.Unpickler(input_file)
+    if find_global is not None:
+        unpickler.find_global = find_global
+        try:
+            unpickler.find_class = find_global
+        except AttributeError:
+            pass
     unpickler.persistent_load = persistent_load
-    unpickler.find_global = find_global
     return unpickler
 
 
-UNPICKLERS = {
-    'Python': PythonUnpickler,
-    'C': CUnpickler}
+def Pickler(
+        output_file, persistent_id, protocol=DEFAULT_PROTOCOL):
+    # Please refer to ZODB._compat for explanation.
+    pickler = pickle.Pickler(output_file, protocol)
+    if not six.PY3:
+        pickler.inst_persistent_id = persistent_id
+    pickler.persistent_id = persistent_id
+    return pickler

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -12,8 +12,8 @@
 #
 ##############################################################################
 
-import cPickle
 import pickle
+import cPickle
 import logging
 
 logger = logging.getLogger('zodbupdate')
@@ -41,7 +41,7 @@ class PythonUnpickler(pickle.Unpickler):
             value = func.__new__(func)
             self.__repickle = True
             logger.warning(
-                u'Warning: Pickle contains ExtensionClass hack for %s' % func)
+                'Warning: Pickle contains ExtensionClass hack for %s' % func)
         else:
             value = func(*args)
         stack[-1] = value
@@ -53,7 +53,6 @@ class PythonUnpickler(pickle.Unpickler):
         return self.__repickle
 
     dispatch[pickle.REDUCE] = load_reduce
-
 
 
 def CUnpickler(input_file, persistent_load, find_global):
@@ -68,4 +67,3 @@ def CUnpickler(input_file, persistent_load, find_global):
 UNPICKLERS = {
     'Python': PythonUnpickler,
     'C': CUnpickler}
-

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -16,6 +16,14 @@ import ZODB._compat
 import logging
 import six
 
+from ZODB.broken import Broken
+
+
+def is_broken(symb):
+    """Return true if the given symbol is broken.
+    """
+    return isinstance(symb, six.class_types) and Broken in symb.__mro__
+
 
 if six.PY3:
     import zodbpickle.pickle as pickle

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -25,6 +25,7 @@ else:
     except ImportError:
         import zodbpickle.pickle as pickle
 
+PicklingError = pickle.PicklingError
 
 logger = logging.getLogger('zodbupdate')
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,37 @@
+[tox]
+envlist =
+    coverage-clean,
+    py27,
+    py34,
+    py35,
+    py36,
+    pypy3,
+    coverage-report
+
+[testenv]
+commands =
+    coverage run --source=zodbupdate -m zope.testrunner --test-path=src {posargs:-vc}
+setenv =
+  COVERAGE_FILE=.coverage.{envname}
+deps =
+    .[test]
+    zope.testrunner
+    coverage
+
+[testenv:coverage-clean]
+deps = coverage
+setenv =
+  COVERAGE_FILE=.coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:coverage-report]
+deps = coverage
+setenv =
+  COVERAGE_FILE=.coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report
+    coverage html
+    coverage


### PR DESCRIPTION
We worked to migrate our Zope application to Python 3, keeping our database. We updated zodbupdate to do the conversion of our databases from Python 2 to Python 3, with success.

Additionally, I kind of wrote zodbupdate, and would like to get back write access to it so I can make a release after merging this pull request. But of course review is welcome.