### PR TITLE
Fix is_broken check with old-style class instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changes
 - Fix tests on Python 2 with ZODB >= 5.4.0, which now uses pickle
   protocol 3.
 
+- Fix is_broken check for old-style class instances.
+
 
 1.0 (2018-02-13)
 ----------------

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -22,7 +22,7 @@ from ZODB.broken import Broken
 def is_broken(symb):
     """Return true if the given symbol is broken.
     """
-    return isinstance(symb, six.class_types) and Broken in symb.__mro__
+    return isinstance(symb, six.class_types) and issubclass(symb, Broken)
 
 
 if six.PY3:


### PR DESCRIPTION
This fixes the following error when `is_broken` gets an old-style class instance:
`AttributeError: class OldData has no attribute '__mro__'`