### PR TITLE
Leave None values untouched during decoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.1 (unreleased)
 ----------------
 
+- When migrating databases to python3, do not fail when converting
+  attributes containing None.
+
 - Fix tests on Python 2 with ZODB >= 5.4.0, which now uses pickle
   protocol 3.
 

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -58,7 +58,7 @@ def decode_attribute(attribute, encoding):
 
     def decode(data):
         value = data.get(attribute)
-        if not isinstance(value, six.text_type):
+        if value is not None and not isinstance(value, six.text_type):
             data[attribute] = value.decode(encoding)
             return True
         return False
@@ -70,7 +70,7 @@ def encode_binary(attribute):
 
     def encode(data):
         value = data.get(attribute)
-        if not isinstance(value, zodbpickle.binary):
+        if value is not None and not isinstance(value, zodbpickle.binary):
             data[attribute] = zodbpickle.binary(value)
             return True
         return False

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -609,6 +609,24 @@ class Python2Tests(Tests):
             )
         )
 
+    def test_encode_binary_leaves_none_untouched(self):
+        from zodbupdate.convert import encode_binary
+        mock = dict()
+        mock['foo'] = None
+        encoder = encode_binary('foo')
+        result = encoder(mock)
+        self.assertEquals(result, False)
+        self.assertEquals(mock['foo'], None)
+
+    def test_decode_attribute_leaves_none_untouched(self):
+        from zodbupdate.convert import decode_attribute
+        mock = dict()
+        mock['foo'] = None
+        encoder = decode_attribute('foo', 'utf-8')
+        result = encoder(mock)
+        self.assertEquals(result, False)
+        self.assertEquals(mock['foo'], None)
+
 
 class Python3Tests(Tests):
 


### PR DESCRIPTION
In real-world cases, some objects in the ZODB have attributes (such as
title) while other objects of the same class have them unset (None).
It's helpful if None would stay as-is while other values can be decoded
based on the rules provided.