### PR TITLE
do not break refs to blobstorage files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.1 (unreleased)
 ----------------
 
+- Skip records for ZODB.blob when migrating database to python3 to not break
+  references to blobfiles.
+
 - When migrating databases to python3, do not fail when converting
   attributes containing None.
 

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -19,7 +19,6 @@ import sys
 import six
 import zodbpickle
 
-from ZODB.blob import Blob
 from ZODB.broken import find_global, Broken, rebuild
 from zodbupdate import utils
 
@@ -27,7 +26,7 @@ logger = logging.getLogger('zodbupdate.serialize')
 known_broken_modules = {}
 
 # types to skip when renaming/migrating databases
-SKIP_TYPES = [Blob]
+SKIP_SYMBS = [('ZODB.blob', 'Blob')]
 
 
 def create_broken_module_for(symb):
@@ -159,7 +158,10 @@ class ObjectRenamer(object):
         loaded and its location is checked to see if it have moved as
         well.
         """
-        if symb_info in self.__renames:
+        if symb_info in SKIP_SYMBS:
+            self.__skipped = True
+            return symb_info
+        elif symb_info in self.__renames:
             self.__changed = True
             return self.__renames[symb_info]
         else:
@@ -296,6 +298,7 @@ class ObjectRenamer(object):
         return None otherwise.
         """
         self.__changed = False
+        self.__skipped = False
 
         unpickler = self.__unpickler(input_file)
         class_meta = unpickler.load()
@@ -303,7 +306,7 @@ class ObjectRenamer(object):
 
         class_meta = self.__update_class_meta(class_meta)
 
-        if class_meta in SKIP_TYPES:
+        if self.__skipped:
             # do not do renames/conversions on blob records
             return None
 


### PR DESCRIPTION
by skipping pickles for ZODB.blob.Blob objects in the rename/convert method blobs do not get broken when running `zodbupdate --pack --convert-py3 --file Data.fs`

as the record's oid stays the same, and also the old serial should be used when saving it back (see https://github.com/zopefoundation/zodbupdate/blob/1.0/src/zodbupdate/update.py#L84) i don't see why we need to skip them here at all.

i need some help with the test `test_blob_pickles_are_left_untouched`:
* skipping/renaming `module1.Factory` does not work as the class_meta is `persistent.mapping.PersistentMapping` instead of `module1.Factory`
* and i don't know how to prove the database record has not been touched.