### PR TITLE
Skip Blob records but not references to Blobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes
 - Fix updating records that reference a broken interface
   when the interface's top-level module is missing.
 
+- Fixed skipping of blob records so that oids in references to blobs
+  are still converted.
+
 
 1.1 (2018-10-05)
 ----------------

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -14,10 +14,12 @@
 ##############################################################################
 
 import ZODB
+import ZODB.blob
 import ZODB.broken
 import ZODB.FileStorage
 import os
 import persistent
+import shutil
 import sys
 import tempfile
 import transaction
@@ -89,25 +91,33 @@ class Tests(unittest.TestCase):
         IOtherFactory.__module__ = 'module2.interfaces'
 
         self.tmphnd, self.dbfile = tempfile.mkstemp()
+        self.tmpblob = tempfile.mkdtemp()
 
-        self.storage = ZODB.FileStorage.FileStorage(self.dbfile)
+        self.storage = ZODB.blob.BlobStorage(
+            self.tmpblob,
+            ZODB.FileStorage.FileStorage(self.dbfile),
+        )
         self.db = ZODB.DB(self.storage)
         self.conn = self.db.open()
         self.root = self.conn.root()
-
-        self._skipped_symbs = zodbupdate.serialize.SKIP_SYMBS
 
     def update(self, **args):
         self.conn.close()
         self.db.close()
         self.storage.close()
 
-        self.storage = ZODB.FileStorage.FileStorage(self.dbfile)
+        self.storage = ZODB.blob.BlobStorage(
+            self.tmpblob,
+            ZODB.FileStorage.FileStorage(self.dbfile),
+        )
         updater = zodbupdate.main.create_updater(self.storage, **args)
         updater()
         self.storage.close()
 
-        self.storage = ZODB.FileStorage.FileStorage(self.dbfile)
+        self.storage = ZODB.blob.BlobStorage(
+            self.tmpblob,
+            ZODB.FileStorage.FileStorage(self.dbfile),
+        )
         self.db = ZODB.DB(self.storage)
         self.conn = self.db.open()
         self.root = self.conn.root()
@@ -134,8 +144,7 @@ class Tests(unittest.TestCase):
         os.unlink(self.dbfile + '.index')
         os.unlink(self.dbfile + '.tmp')
         os.unlink(self.dbfile + '.lock')
-
-        zodbupdate.serialize.SKIP_SYMBS = self._skipped_symbs
+        shutil.rmtree(self.tmpblob)
 
     def test_no_transaction_if_no_changes(self):
         # If an update run doesn't produce any changes it won't commit the
@@ -179,45 +188,6 @@ class Tests(unittest.TestCase):
             self.root['test'].__class__.__name__)
         renames = updater.processor.get_rules(implicit=True)
         self.assertEqual({}, renames)
-
-    def test_skipped_types_are_left_untouched(self):
-        skipped = sys.modules['module1'].Factory()
-        self.root['skipped'] = skipped
-        transaction.commit()
-
-        self.assertIn(('ZODB.blob', 'Blob'), zodbupdate.serialize.SKIP_SYMBS)
-        zodbupdate.serialize.SKIP_SYMBS += [('module1', 'Factory')]
-
-        oid = self.root['skipped']._p_oid
-        old_pickle, old_serial = self.storage.load(oid)
-
-        self.update(
-            default_renames={
-                ('module1', 'Factory'): ('module2', 'OtherFactory')})
-
-        pickle, serial = self.storage.load(oid)
-        self.assertEqual(old_pickle, pickle)
-        self.assertEqual(old_serial, serial)
-
-    def test_not_skipped_types_are_touched(self):
-        skipped = sys.modules['module1'].Factory()
-        self.root['skipped'] = skipped
-        transaction.commit()
-
-        self.assertNotIn(
-            ('module1', 'Factory'),
-            zodbupdate.serialize.SKIP_SYMBS)
-
-        oid = self.root['skipped']._p_oid
-        old_pickle, old_serial = self.storage.load(oid)
-
-        self.update(
-            default_renames={
-                ('module1', 'Factory'): ('module2', 'OtherFactory')})
-
-        pickle, serial = self.storage.load(oid)
-        self.assertNotEqual(old_pickle, pickle)
-        self.assertNotEqual(old_serial, serial)
 
 
 class Python2Tests(Tests):
@@ -678,6 +648,28 @@ class Python2Tests(Tests):
         result = encoder(mock)
         self.assertEquals(result, False)
         self.assertEquals(mock['foo'], None)
+
+    def test_blobs_are_left_untouched(self):
+        from zodbupdate.convert import encode_binary
+
+        blob = ZODB.blob.Blob()
+        self.root['blob'] = blob
+        transaction.commit()
+
+        oid = self.root['blob']._p_oid
+        old_pickle, old_serial = self.storage.load(oid)
+
+        self.update(convert_py3=True)
+
+        pickle, serial = self.storage.load(oid)
+        self.assertEqual(old_pickle, pickle)
+        self.assertEqual(old_serial, serial)
+
+        # make sure the reference to the blob was converted
+        self.assertIn(
+            b'C\x08\x00\x00\x00\x00\x00\x00\x00\x01cZODB.blob',
+            self.storage.load(self.root._p_oid, '')[0]
+        )
 
 
 class Python3Tests(Tests):

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -685,8 +685,6 @@ class Python2Tests(Tests):
         self.assertEquals(mock['foo'], None)
 
     def test_blobs_are_left_untouched(self):
-        from zodbupdate.convert import encode_binary
-
         blob = ZODB.blob.Blob()
         self.root['blob'] = blob
         transaction.commit()


### PR DESCRIPTION
This fixes the skipping of Blob records when converting to Python 3. The previous approach skipped Blob records, but also skipped over the oids in references to Blobs, so that they were not converted to bytes.