### PR TITLE
Make it work in Python 3 with a default codec

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,8 @@ users to use that option. If they never pack their storage, it is a good
 occasion).
 
 
-Migration to Python 3
----------------------
+Converting to Python 3
+----------------------
 
 ``zodbupdate`` can be used to migrate a database created with a Python
 2 application to be usable with the same application in Python 3. To
@@ -152,7 +152,7 @@ decoders from the entry points::
           """)
 
 Decoders are dictionaries that specifies as keys attributes on
-Persistent classes that must either be encode as bytes (if the value
+Persistent classes that must either be encoded as bytes (if the value
 is ``binary``) or decoded to unicode using value as encoding (for
 instance ``utf-8`` here)::
 
@@ -162,6 +162,24 @@ instance ``utf-8`` here)::
 
 Please note that for the moment only attributes on Persistent classes
 are supported.
+
+Converting to Python 3 from within Python 3
+-------------------------------------------
+
+``zodbupdate`` can also be run from within Python 3 to convert a database
+created with Python 2 to be usable in Python 3. However this works
+slightly differently than when running the conversion using Python 2.
+In Python 3 you must specify a default encoding to use while unpickling strings:
+``zodbupdate --pack --convert-py3 --encoding utf-8``.
+
+For each string in the database, zodbupdate will convert it as follows:
+
+1. If it's an attribute configured explicitly via a decoder as described
+   above, it will be decoded or encoded as specified there.
+2. Otherwise the value will be decoded using the encoding specified
+   on the command line.
+3. If there is an error while decoding using the encoding specified
+   on the command line, the value will be stored as bytes.
 
 Problems and solutions
 ----------------------

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -3,6 +3,7 @@ import six
 import datetime
 import zodbpickle
 import pkg_resources
+from zodbupdate import utils
 
 
 logger = logging.getLogger('zodbupdate')
@@ -13,12 +14,12 @@ class Datetime(datetime.datetime):
     def __reduce__(self):
         type_info, args = super(Datetime, self).__reduce__()
         assert len(args) > 0
-        return (datetime.datetime, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.datetime, (utils.safe_binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
         type_info, args = super(Datetime, self).__reduce_ex__(protocol)
         assert len(args) > 0
-        return (datetime.datetime, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.datetime, (utils.safe_binary(args[0]),) + args[1:])
 
 
 class Date(datetime.date):
@@ -26,12 +27,12 @@ class Date(datetime.date):
     def __reduce__(self):
         type_info, args = super(Date, self).__reduce__()
         assert len(args) > 0
-        return (datetime.date, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.date, (utils.safe_binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
         type_info, args = super(Date, self).__reduce_ex__(protocol)
         assert len(args) > 0
-        return (datetime.date, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.date, (utils.safe_binary(args[0]),) + args[1:])
 
 
 class Time(datetime.time):
@@ -39,16 +40,18 @@ class Time(datetime.time):
     def __reduce__(self):
         type_info, args = super(Time, self).__reduce__()
         assert len(args) > 0
-        return (datetime.time, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.time, (utils.safe_binary(args[0]),) + args[1:])
 
     def __reduce_ex__(self, protocol):
         type_info, args = super(Time, self).__reduce_ex__(protocol)
         assert len(args) > 0
-        return (datetime.time, (zodbpickle.binary(args[0]),) + args[1:])
+        return (datetime.time, (utils.safe_binary(args[0]),) + args[1:])
 
 
 def default_renames():
     return {
+        ('UserDict', 'UserDict'): ('collections', 'UserDict'),
+        ('__builtin__', 'set'): ('builtins', 'set'),
         ('datetime', 'datetime'): ('zodbupdate.convert', 'Datetime'),
         ('datetime', 'date'): ('zodbupdate.convert', 'Date'),
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}
@@ -58,7 +61,11 @@ def decode_attribute(attribute, encoding):
 
     def decode(data):
         value = data.get(attribute)
-        if value is not None and not isinstance(value, six.text_type):
+        if value is not None:
+            if isinstance(value, six.text_type):
+                if encoding == utils.ENCODING:
+                    return False
+                value = utils.safe_binary(value)
             data[attribute] = value.decode(encoding)
             return True
         return False
@@ -71,7 +78,7 @@ def encode_binary(attribute):
     def encode(data):
         value = data.get(attribute)
         if value is not None and not isinstance(value, zodbpickle.binary):
-            data[attribute] = zodbpickle.binary(value)
+            data[attribute] = utils.safe_binary(value)
             return True
         return False
 
@@ -103,4 +110,4 @@ def update_magic_data_fs(filename):
         logger.info("Updating magic marker for {}".format(filename))
         with open(filename, 'r+b') as data_fs:
             # Override the magic.
-            data_fs.write('FS30')
+            data_fs.write(b'FS30')

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -149,8 +149,8 @@ class Updater(object):
               not storage.supportsUndo()):
             # If we can't iterate only through the recent records,
             # iterate on all. Of course doing a pack before help :).
-            for transaction in storage.iterator():
-                for rec in transaction:
+            for transaction_ in storage.iterator():
+                for rec in transaction_:
                     yield rec.oid, rec.tid, io.BytesIO(rec.data)
         else:
             raise SystemExit(

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -38,14 +38,17 @@ class Updater(object):
     def __init__(
             self, storage, dry=False, renames=None, decoders=None,
             start_at='0x00', debug=False, repickle_all=False,
-            pickle_protocol=zodbupdate.utils.DEFAULT_PROTOCOL):
+            pickle_protocol=zodbupdate.utils.DEFAULT_PROTOCOL,
+            encoding='ASCII'):
         self.dry = dry
         self.storage = storage
         self.processor = zodbupdate.serialize.ObjectRenamer(
             renames=renames,
             decoders=decoders,
             pickle_protocol=pickle_protocol,
-            repickle_all=repickle_all)
+            repickle_all=repickle_all,
+            encoding=encoding,
+        )
         self.start_at = start_at
         self.debug = debug
 
@@ -95,7 +98,7 @@ class Updater(object):
             self.__commit_transaction(t, record_count != 0, commit_count)
         except Exception as error:
             if not self.debug:
-                raise error
+                raise
             import sys
             import pdb
             (type, value, traceback) = sys.exc_info()

--- a/src/zodbupdate/update.py
+++ b/src/zodbupdate/update.py
@@ -127,7 +127,7 @@ class Updater(object):
                     logger.error(
                         'Warning: Jumping record {}, '
                         'referencing missing key in database: {}'.format(
-                            (ZODB.utils.oid_repr(oid), str(e))))
+                            ZODB.utils.oid_repr(oid), str(e)))
                 else:
                     yield oid, tid, io.BytesIO(data)
 

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -15,6 +15,8 @@
 import ZODB._compat
 import logging
 import six
+import sys
+import zodbpickle
 
 from ZODB.broken import Broken
 
@@ -30,8 +32,8 @@ if six.PY3:
 
     class UnpicklerImpl(pickle.Unpickler):
 
-        def __init__(self, f):
-            super(UnpicklerImpl, self).__init__(f)
+        def __init__(self, f, **kw):
+            super(UnpicklerImpl, self).__init__(f, **kw)
 
         # Py3: Python 3 doesn't allow assignments to find_global,
         # instead, find_class can be overridden
@@ -60,9 +62,9 @@ DEFAULT_PROTOCOL = ZODB._compat._protocol
 
 
 def Unpickler(
-        input_file, persistent_load, find_global):
+        input_file, persistent_load, find_global, **kw):
     # Please refer to ZODB._compat for explanation.
-    unpickler = UnpicklerImpl(input_file)
+    unpickler = UnpicklerImpl(input_file, **kw)
     if find_global is not None:
         unpickler.find_global = find_global
         try:
@@ -81,3 +83,13 @@ def Pickler(
         pickler.inst_persistent_id = persistent_id
     pickler.persistent_id = persistent_id
     return pickler
+
+
+ENCODING = sys.getdefaultencoding()
+
+def safe_binary(value):
+    if isinstance(value, bytes):
+        return zodbpickle.binary(value)
+    if isinstance(value, six.text_type):
+        return zodbpickle.binary(value.encode(ENCODING))
+    return value


### PR DESCRIPTION
This makes it possible to run zodbupdate using Python 3, with some tradeoffs compared to running it in Python 2.

In Python 3 it is possible to pass a default encoding and errors='bytes' to the unpickler. This means that it will attempt to decode strings using that encoding, but if it fails it will load them as bytes. For cases that we know should be bytes (like oids, datetimes, and attributes explicitly configured as binary), if the decoding succeeded we re-encode using the same codec before pickling.

This is handy in cases where most strings in the database are encoded the same way and it's difficult to identify all of them explicitly in decoder entry points.

The tradeoffs between running in Python 2 and Python 3 have to do with situations where values cannot be decoded using the default codec. Running zodbupdate in Python 2, the value will remain untouched as a string in the pickle, and Python 3 may raise a UnicodeDecodeError while trying to load it. Running zodbupdate in Python 3, it will either accidentally decode successfully using the wrong codec or accidentally fail to decode and be pickled as bytes, but it should always be possible to unpickle the result, whether or not it's the type the app code expects. As a result, it's safest to explicitly configure the codec using a decoder entry point for any attributes that don't use the default.