### PR TITLE
Fallback encodings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 1.2 (unreleased)
 ----------------
 
+- Enable fallback encodings for old/grown ZODBs.
+
 - Switch to use `argparse` b/c `optparse` is deprecated.
 
 - Add ability to run the Python 3 migration with a default encoding for

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 1.2 (unreleased)
 ----------------
 
+- Switch to use `argparse` b/c `optparse` is deprecated.
+
 - Add ability to run the Python 3 migration with a default encoding for
   ``str`` objects.
   (`#14 <https://github.com/zopefoundation/zodbupdate/pull/14>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 1.2 (unreleased)
 ----------------
 
-- Enable fallback encodings for old/grown ZODBs.
+- Enable fallback encodings for Python 3 conversion for old/grown ZODBs using
+   the new command line option ``--encoding-fallback``.
+  (`#15 <https://github.com/zopefoundation/zodbupdate/pull/15>`_)
 
 - Switch to use `argparse` b/c `optparse` is deprecated.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes
    the new command line option ``--encoding-fallback``.
   (`#15 <https://github.com/zopefoundation/zodbupdate/pull/15>`_)
 
-- Switch to use `argparse` b/c `optparse` is deprecated.
+- Switch to use `argparse` as `optparse` is deprecated.
 
 - Add ability to run the Python 3 migration with a default encoding for
   ``str`` objects.

--- a/setup.py
+++ b/setup.py
@@ -67,4 +67,6 @@ setup(name='zodbupdate',
       zip_safe=False,
       entry_points={
           "console_scripts": ['zodbupdate = zodbupdate.main:main']
-      })
+      },
+      test_suite="zodbupdate.tests.test_suite",
+)

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -57,7 +57,7 @@ def default_renames():
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}
 
 
-def decode_attribute(attribute, encoding, encoding_fallbacks=[]):
+def decode_attribute(attribute, encoding, encoding_fallbacks=None):
 
     def decode(data):
         value = data.get(attribute)
@@ -70,6 +70,9 @@ def decode_attribute(attribute, encoding, encoding_fallbacks=[]):
         try:
             data[attribute] = value.decode(encoding)
         except UnicodeDecodeError:
+            if not encoding_fallbacks:
+                logger.error("No encoding-fallbacks given!")
+                raise
             for encoding_fallback in encoding_fallbacks:
                 try:
                     data[attribute] = value.decode(encoding_fallback)
@@ -78,7 +81,7 @@ def decode_attribute(attribute, encoding, encoding_fallbacks=[]):
                 logger.warning(
                     'Encoding fallback to "{fallback_encoding:s}" '
                     'while decoding attribute "{attribute:s}" '
-                    'from: \n{value}\nto:\n{data_attribute}'.format(
+                    'from: \n{value!r}\nto:\n{data_attribute}'.format(
                         fallback_encoding=encoding_fallback,
                         attribute=attribute,
                         value=value,

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -57,18 +57,50 @@ def default_renames():
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}
 
 
-def decode_attribute(attribute, encoding):
+def decode_attribute(attribute, encoding, encoding_fallbacks=[]):
 
     def decode(data):
         value = data.get(attribute)
-        if value is not None:
-            if isinstance(value, six.text_type):
-                if encoding == utils.ENCODING:
-                    return False
-                value = utils.safe_binary(value)
+        if value is None:
+            return False
+        if isinstance(value, six.text_type):
+            if encoding == utils.ENCODING:
+                return False
+            value = utils.safe_binary(value)
+        try:
             data[attribute] = value.decode(encoding)
-            return True
-        return False
+        except UnicodeDecodeError:
+            for encoding_fallback in encoding_fallbacks:
+                try:
+                    data[attribute] = value.decode(encoding_fallback)
+                except UnicodeDecodeError:
+                    continue
+                logger.warning(
+                    'Encoding fallback to "{fallback_encoding:s}" '
+                    'while decoding attribute "{attribute:s}" '
+                    'from: \n{value}\nto:\n{data_attribute}'.format(
+                        fallback_encoding=encoding_fallback,
+                        attribute=attribute,
+                        value=value,
+                        data_attribute=data[attribute],
+                    )
+                )
+                logger.debug(
+                    "Encoding fallback on data:\n{data}".format(data=data)
+                )
+                return True
+            else:
+                raise UnicodeDecodeError(
+                    'encoding={encoding}, fallback_encodings={fallbacks}'.format(
+                        encoding=encoding,
+                        fallbacks=encoding_fallbacks,
+                    ),
+                    value,
+                    0,
+                    0,
+                    'Neither with encoding nor with fallbacks.',
+                )
+        return True
 
     return decode
 
@@ -85,7 +117,7 @@ def encode_binary(attribute):
     return encode
 
 
-def load_decoders():
+def load_decoders(encoding_fallbacks=[]):
     decoders = {}
     for entry_point in pkg_resources.iter_entry_points('zodbupdate.decode'):
         definition = entry_point.load()
@@ -96,7 +128,7 @@ def load_decoders():
                     encode_binary(attribute))
             else:
                 decoders.setdefault((module, cls), []).append(
-                    decode_attribute(attribute, encoding))
+                    decode_attribute(attribute, encoding, encoding_fallbacks))
         logger.info('Loaded {} decode rules from {}:{}'.format(
             len(definition), entry_point.module_name, entry_point.name))
     return decoders

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -70,7 +70,7 @@ def convert_with_fallbacks(value, attribute, encoding, encoding_fallbacks):
                 converted = value.decode(encoding_fallback)
             except UnicodeDecodeError:
                 continue
-            
+
             logger.warning(
                 'Encoding fallback to "{fallback_encoding:s}" '
                 'while decoding attribute "{attribute:s}" '.format(
@@ -79,7 +79,7 @@ def convert_with_fallbacks(value, attribute, encoding, encoding_fallbacks):
                 )
             )
             logger.debug(
-                "Decoded from: \n{value!r}\nto:\n{converted}".format(
+                u"Decoded from: \n{value!r}\nto:\n{converted}".format(
                     value=value,
                     converted=converted,
                 )
@@ -96,8 +96,9 @@ def convert_with_fallbacks(value, attribute, encoding, encoding_fallbacks):
                 0,
                 'Neither with encoding nor with fallbacks.',
             )
-    
+
     return converted
+
 
 def decode_attribute(attribute, encoding, encoding_fallbacks=None):
 
@@ -109,7 +110,9 @@ def decode_attribute(attribute, encoding, encoding_fallbacks=None):
             if encoding == utils.ENCODING:
                 return False
             value = utils.safe_binary(value)
-        data[attribute] = convert_with_fallbacks(value, attribute, encoding, encoding_fallbacks)
+        data[attribute] = convert_with_fallbacks(
+            value, attribute, encoding, encoding_fallbacks
+        )
         return True
 
     return decode

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -16,7 +16,7 @@ import ZODB.FileStorage
 import ZODB.config
 import ZODB.serialize
 import logging
-import optparse
+import argparse
 import pkg_resources
 import pprint
 import six
@@ -28,41 +28,41 @@ import zodbupdate.utils
 logger = logging.getLogger('zodbupdate')
 
 
-parser = optparse.OptionParser(
+parser = argparse.ArgumentParser(
     description=("Updates all references to classes to "
                  "their canonical location."))
-parser.add_option(
+parser.add_argument(
     "-f", "--file",
     help="load FileStorage")
-parser.add_option(
+parser.add_argument(
     "-c", "--config",
     help="load storage from config file")
-parser.add_option(
+parser.add_argument(
     "-n", "--dry-run", action="store_true",
     help="perform a trial run with no changes made")
-parser.add_option(
+parser.add_argument(
     "-s", "--save-renames",
     help="save automatically determined rename rules to file")
-parser.add_option(
+parser.add_argument(
     "-q", "--quiet", action="store_true",
     help="suppress non-error messages")
-parser.add_option(
+parser.add_argument(
     "-v", "--verbose", action="store_true",
     help="more verbose output")
-parser.add_option(
+parser.add_argument(
     "-o", "--oid",
     help="start with provided oid in hex format, ex: 0xaa1203")
-parser.add_option(
+parser.add_argument(
     "-d", "--debug", action="store_true",
     help="post mortem pdb on failure")
-parser.add_option(
+parser.add_argument(
     "--pack", action="store_true", dest="pack",
     help=("pack the storage when done. use in conjunction of -c "
           "if you have blobs storage"))
-parser.add_option(
-    "--convert-py3", action="store_true",  dest="convert_py3",
+parser.add_argument(
+    "--convert-py3", action="store_true", dest="convert_py3",
     help="convert pickle format to protocol 3 and adjust bytes")
-parser.add_option(
+parser.add_argument(
     '--encoding', dest="encoding",
     help="used for decoding pickled strings in py3"
 )
@@ -167,24 +167,24 @@ def format_renames(renames):
 
 
 def main():
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
-    setup_logger(quiet=options.quiet, verbose=options.verbose)
+    setup_logger(quiet=args.quiet, verbose=args.verbose)
 
-    if options.file and options.config:
+    if args.file and args.config:
         raise AssertionError(
             'Exactly one of --file or --config must be given.')
 
     # Magic bytes need to be converted at the end when running in Python 2
     # but at the beginning when running in Python 3 so that FileStorage
     # doesn't complain.
-    if options.convert_py3 and six.PY3 and not options.dry_run:
-        zodbupdate.convert.update_magic_data_fs(options.file)
+    if args.convert_py3 and six.PY3 and not args.dry_run:
+        zodbupdate.convert.update_magic_data_fs(args.file)
 
-    if options.file:
-        storage = ZODB.FileStorage.FileStorage(options.file)
-    elif options.config:
-        with open(options.config) as config:
+    if args.file:
+        storage = ZODB.FileStorage.FileStorage(args.file)
+    elif args.config:
+        with open(args.config) as config:
             storage = ZODB.config.storageFromFile(config)
     else:
         raise AssertionError(
@@ -192,11 +192,11 @@ def main():
 
     updater = create_updater(
         storage,
-        start_at=options.oid,
-        convert_py3=options.convert_py3,
-        encoding=options.encoding,
-        dry_run=options.dry_run,
-        debug=options.debug)
+        start_at=args.oid,
+        convert_py3=args.convert_py3,
+        encoding=args.encoding,
+        dry_run=args.dry_run,
+        debug=args.debug)
     try:
         updater()
     except Exception as error:
@@ -208,16 +208,16 @@ def main():
         updater.processor.get_rules(implicit=True))
     if implicit_renames:
         logger.info('Found new rules: {}'.format(implicit_renames))
-    if options.save_renames:
-        logger.info('Saving rules into {}'.format(options.save_renames))
-        with open(options.save_renames, 'w') as output:
+    if args.save_renames:
+        logger.info('Saving rules into {}'.format(args.save_renames))
+        with open(args.save_renames, 'w') as output:
             output.write('renames = {}'.format(
                 format_renames(updater.processor.get_rules(
                     implicit=True, explicit=True))))
-    if options.pack:
+    if args.pack:
         logger.info('Packing storage ...')
         storage.pack(time.time(), ZODB.serialize.referencesf)
     storage.close()
 
-    if options.convert_py3 and six.PY2 and not options.dry_run:
-        zodbupdate.convert.update_magic_data_fs(options.file)
+    if args.convert_py3 and six.PY2 and not args.dry_run:
+        zodbupdate.convert.update_magic_data_fs(args.file)


### PR DESCRIPTION
Add new argument ``--encoding-fallback`` and try to use them if the main encoding fails. Warn if so.
This is useful migrating old ZODBs where i.e. `latin1` was the default encoding and later it was `utf8`. Then the ZODB may contain mixed encodings for the same attribute on different instances.

Also: replace deprecated `optparse` with `argparse`.