### PR TITLE
Support converting sets.Set() objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes
 - Support converting sets.Set() objects from ancient Python 2 versions.
   (`issue 23 <https://github.com/zopefoundation/zodbupdate/issue/23>`_)
 
+- Convert set objects to ``builtins.set`` without relying on ZODB.broken.rebuild.
+  (`issue 25 <https://github.com/zopefoundation/zodbupdate/pull/25>`_)
+
 
 1.2 (2019-05-09)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Support converting sets.Set() objects from ancient Python 2 versions.
+  (`issue 23 <https://github.com/zopefoundation/zodbupdate/issue/23>`_)
 
 
 1.2 (2019-05-09)

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -9,6 +9,19 @@ from zodbupdate import utils
 logger = logging.getLogger('zodbupdate')
 
 
+try:
+    import sets
+except ImportError:
+    pass
+else:
+    class Set(sets.Set):
+        def __reduce__(self):
+            return set(self).__reduce__()
+
+        def __reduce_ex__(self, protocol):
+            return set(self).__reduce_ex__(protocol)
+
+
 class Datetime(datetime.datetime):
 
     def __reduce__(self):
@@ -52,6 +65,7 @@ def default_renames():
     return {
         ('UserDict', 'UserDict'): ('collections', 'UserDict'),
         ('__builtin__', 'set'): ('builtins', 'set'),
+        ('sets', 'Set'): ('zodbupdate.convert', 'Set'),
         ('datetime', 'datetime'): ('zodbupdate.convert', 'Datetime'),
         ('datetime', 'date'): ('zodbupdate.convert', 'Date'),
         ('datetime', 'time'): ('zodbupdate.convert', 'Time')}

--- a/src/zodbupdate/convert.py
+++ b/src/zodbupdate/convert.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import sys
+import types
 
 import pkg_resources
 import six
@@ -17,7 +18,6 @@ try:
 except ImportError:
     # Python 2
     import __builtin__
-    import types
 
     # NB: this class _must_ be named 'set', or the pickling trick won't work!
     class set(__builtin__.set):
@@ -40,6 +40,20 @@ except ImportError:
 
         def __reduce_ex__(self, protocol):
             return python3_compatible_set(self).__reduce_ex__(protocol)
+else:
+    # Python 3:
+    class Set(object):
+        def __setstate__(self, data):
+            self._data, = data
+
+        def __reduce__(self):
+            return builtins.set(self._data).__reduce__()
+
+        def __reduce_ex__(self, protocol):
+            return builtins.set(self._data).__reduce_ex__(protocol)
+
+    sys.modules['sets'] = types.ModuleType('sets')
+    sys.modules['sets'].Set = Set
 
 
 class Datetime(datetime.datetime):

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -313,7 +313,7 @@ class Python2Tests(Tests):
             'X\x0e\x00\x00\x00text \xc3\xa9l\xc3\xa9gantq\x04s.',
             self.storage.load(self.root['test']._p_oid, '')[0])
 
-    def test_convert_attribute_to_unicode(self):
+    def test_convert_attribute_to_unicode_2(self):
         from zodbupdate.convert import decode_attribute
 
         test = sys.modules['module1'].Factory()

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -351,11 +351,19 @@ class Python2Tests(Tests):
 
         # This is what a Python 2 pickle looks like -- we'll reuse it
         # in Python3Tests
-        self.assertEqual(
-            b'\x80\x03cmodule1\nFactory\nq\x01.'
-            b'\x80\x03}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
-            b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
-            self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertIn(
+            self.storage.load(self.root['test']._p_oid, '')[0],
+            (
+                # ZODB < 5.4
+                b'\x80\x02cmodule1\nFactory\nq\x01.'
+                b'\x80\x02}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
+                b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
+                # ZODB >= 5.4
+                b'\x80\x03cmodule1\nFactory\nq\x01.'
+                b'\x80\x03}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
+                b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
+            )
+        )
 
         self.update(convert_py3=True)
 
@@ -376,11 +384,19 @@ class Python2Tests(Tests):
 
         # This is what a Python 2 pickle looks like -- we'll reuse it
         # in Python3Tests
-        self.assertEqual(
-            b'\x80\x03cmodule1\nFactory\nq\x01.'
-            b'\x80\x03}q\x02U\x11favourite_numbersq\x03csets\nSet\nq\x04'
-            b')\x81q\x05}q\x06(K\xaa\x88K\xbb\x88K\xcc\x88K\xdd\x88u\x85bs.',
-            self.storage.load(self.root['test']._p_oid, '')[0])
+        self.assertIn(
+            self.storage.load(self.root['test']._p_oid, '')[0],
+            (
+                # ZODB < 5.4
+                b'\x80\x02cmodule1\nFactory\nq\x01.'
+                b'\x80\x02}q\x02U\x11favourite_numbersq\x03csets\nSet\nq\x04'
+                b')\x81q\x05}q\x06(K\xaa\x88K\xbb\x88K\xcc\x88K\xdd\x88u\x85bs.',
+                # ZODB >= 5.4
+                b'\x80\x03cmodule1\nFactory\nq\x01.'
+                b'\x80\x03}q\x02U\x11favourite_numbersq\x03csets\nSet\nq\x04'
+                b')\x81q\x05}q\x06(K\xaa\x88K\xbb\x88K\xcc\x88K\xdd\x88u\x85bs.',
+            )
+        )
 
         self.update(convert_py3=True)
 
@@ -894,8 +910,8 @@ class Python3Tests(Tests):
         test.favourite_numbers = {0xaa, 0xbb, 0xcc, 0xdd}
         self.root['test'] = test
         pickle_data = (
-            b'\x80\x03cmodule1\nFactory\nq\x01.'
-            b'\x80\x03}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
+            b'\x80\x02cmodule1\nFactory\nq\x01.'
+            b'\x80\x02}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
             b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.'
         )
         with overridePickle(test, pickle_data):
@@ -915,8 +931,8 @@ class Python3Tests(Tests):
         test.favourite_numbers = {0xaa, 0xbb, 0xcc, 0xdd}
         self.root['test'] = test
         pickle_data = (
-            b'\x80\x03cmodule1\nFactory\nq\x01.'
-            b'\x80\x03}q\x02U\x11favourite_numbersq\x03csets\nSet\nq\x04'
+            b'\x80\x02cmodule1\nFactory\nq\x01.'
+            b'\x80\x02}q\x02U\x11favourite_numbersq\x03csets\nSet\nq\x04'
             b')\x81q\x05}q\x06(K\xaa\x88K\xbb\x88K\xcc\x88K\xdd\x88u\x85bs.'
         )
         with overridePickle(test, pickle_data):

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -340,23 +340,20 @@ class Python2Tests(Tests):
             'C\x08\x00\x00\x00\x00\x00\x00\x00\x02h\x01\x86q\x04Qs.',
             self.storage.load(self.root['test']._p_oid, '')[0])
 
-# XXX: this fails because there's no builtins.set on Python 2 so what gets
-# stored is a call to ZODB.broken.rebuild()
-#
-#  def test_convert_set_to_py3(self):
-#      test = sys.modules['module1'].Factory()
-#      test.favourite_numbers = {0xaa, 0xbb, 0xcc, 0xdd}
-#      self.root['test'] = test
-#      transaction.commit()
-#
-#      self.update(convert_py3=True)
-#
-#      # Protocol is 3 (x80x03) now and __builtin__.set is now builtins.set.
-#      self.assertEqual(
-#          '\x80\x03cmodule1\nFactory\nq\x01.'
-#          '\x80\x03}q\x02U\x11favourite_numbersq\x03cbuiltins\nset\n'
-#          'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
-#          self.storage.load(self.root['test']._p_oid, '')[0])
+    def test_convert_set_to_py3(self):
+        test = sys.modules['module1'].Factory()
+        test.favourite_numbers = {0xaa, 0xbb, 0xcc, 0xdd}
+        self.root['test'] = test
+        transaction.commit()
+
+        self.update(convert_py3=True)
+
+        # Protocol is 3 (x80x03) now and __builtin__.set is now builtins.set.
+        self.assertEqual(
+            b'\x80\x03cmodule1\nFactory\nq\x01.'
+            b'\x80\x03}q\x02U\x11favourite_numbersq\x03cbuiltins\nset\n'
+            b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
+            self.storage.load(self.root['test']._p_oid, '')[0])
 
     def test_convert_sets_Set_to_py3(self):
         import sets
@@ -370,12 +367,10 @@ class Python2Tests(Tests):
 
         # Protocol is 3 (x80x03) now and sets.Set is encoded
         # as a builtin set
-        # XXX: this should refer to builtins.set, not __builtin__.set, but
-        # see the previous commented-out test about ZODB.broken.rebuild()
         self.assertEqual(
-            '\x80\x03cmodule1\nFactory\nq\x01.'
-            '\x80\x03}q\x02U\x11favourite_numbersq\x03c__builtin__\nset\n'
-            'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
+            b'\x80\x03cmodule1\nFactory\nq\x01.'
+            b'\x80\x03}q\x02U\x11favourite_numbersq\x03cbuiltins\nset\n'
+            b'q\x04]q\x05(K\xaaK\xbbK\xccK\xdde\x85Rq\x06s.',
             self.storage.load(self.root['test']._p_oid, '')[0])
 
     def test_convert_datetime_to_py3(self):


### PR DESCRIPTION
Fixes #23.

This PR could use some work:
- [x] tests!
- [x] it doesn't work when run on Python 3
- [x] it produces pickles refering to `__builtin__.set` instead of `builtins.set`