### PR TITLE
Fail with explanation when opening a Python 2 ZODB with --dry-run on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,8 @@ Changes
 
 1.4 (unreleased)
 ----------------
-
-- Nothing changed yet.
+- Fail with explanation when opening a Python 2 ZODB with --dry-run on Python 3
+  (`#22 <https://github.com/zopefoundation/zodbupdate/issues/22>`_)
 
 
 1.3 (2019-07-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,9 @@
 [buildout]
 develop = .
-parts = zodbupdate test
+parts =
+    zodbupdate
+    scripts
+    test
 
 [test]
 recipe = zc.recipe.testrunner
@@ -9,3 +12,10 @@ eggs = zodbupdate[test]
 [zodbupdate]
 recipe = zc.recipe.egg
 eggs = zodbupdate
+
+[scripts]
+recipe = zc.recipe.egg
+eggs =
+    tox
+scripts =
+    tox

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -192,6 +192,13 @@ def main():
     # doesn't complain.
     if args.convert_py3 and six.PY3 and not args.dry_run:
         zodbupdate.convert.update_magic_data_fs(args.file)
+    elif six.PY3 and args.dry_run:
+        zodb_magic = zodbupdate.utils.get_zodb_magic(args.file)
+        if zodb_magic != ZODB.FileStorage.packed_version:
+            raise AssertionError(
+                'You cannot use --dry-run under Python 3 with a ZODB '
+                'created under Python 2 as --dry-run does not rewrite the '
+                'magic header data before opening the ZODB file.')
 
     if args.file:
         storage = ZODB.FileStorage.FileStorage(args.file)

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -195,7 +195,7 @@ def main():
     elif args.convert_py3 and six.PY3 and args.dry_run:
         zodb_magic = zodbupdate.utils.get_zodb_magic(args.file)
         if zodb_magic != ZODB.FileStorage.packed_version:
-            raise AssertionError(
+            raise SystemExit(
                 'You cannot use --dry-run under Python 3 with a ZODB '
                 'created under Python 2 as --dry-run does not rewrite the '
                 'magic header data before opening the ZODB file.')

--- a/src/zodbupdate/main.py
+++ b/src/zodbupdate/main.py
@@ -192,7 +192,7 @@ def main():
     # doesn't complain.
     if args.convert_py3 and six.PY3 and not args.dry_run:
         zodbupdate.convert.update_magic_data_fs(args.file)
-    elif six.PY3 and args.dry_run:
+    elif args.convert_py3 and six.PY3 and args.dry_run:
         zodb_magic = zodbupdate.utils.get_zodb_magic(args.file)
         if zodb_magic != ZODB.FileStorage.packed_version:
             raise AssertionError(

--- a/src/zodbupdate/utils.py
+++ b/src/zodbupdate/utils.py
@@ -93,3 +93,9 @@ def safe_binary(value):
     if isinstance(value, six.text_type):
         return zodbpickle.binary(value.encode(ENCODING))
     return value
+
+
+def get_zodb_magic(filepath):
+    """ Read the first four bytes of a ZODB file to get its magic """
+    with open(filepath, 'rb') as fp:
+        return fp.read(4)


### PR DESCRIPTION
Fixes #22 

This doesn't fix the underlying issue but it will at least tell users what's happening instead of just blowing up with an error that only makes sense to experts.
