### PR TITLE
Add tests with RelStorage and sqlite.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changes
 ----------------
 
 - Test with history-free and history-preserving RelStorage. Note that
-  history-preserving RelStorage requires RelStorage 3.3 or above.
+  history-preserving RelStorage requires RelStorage 3.3 or above, and
+  Python 2.7 or Python 3.6 and above.
   (`#30 <https://github.com/zopefoundation/zodbupdate/issues/30>`__)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 1.6 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Test with history-free and history-preserving RelStorage. Note that
+  history-preserving RelStorage requires RelStorage 3.3 or above.
+  (`#30 <https://github.com/zopefoundation/zodbupdate/issues/30>`__)
 
 
 1.5 (2020-07-28)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ def read(x):
 tests_require = [
     'persistent',
     'zope.interface',
+    'relstorage',
 ]
 
 setup(name='zodbupdate',

--- a/src/zodbupdate/tests.py
+++ b/src/zodbupdate/tests.py
@@ -1353,9 +1353,16 @@ class Python2RelStorageHPTests(RelStorageHPMixin, Python2Tests):
     pass
 
 
+# On Python 3, the RelStorage sqlite support is only available with Python 3.6
+# and above.
+
+@unittest.skipIf(sys.version_info[:2] < (3, 6),
+                 "RelStorage+sqlite only available on Python 3.6+")
 class Python3RelStorageHFTests(RelStorageHFMixin, Python3Tests):
     pass
 
 
+@unittest.skipIf(sys.version_info[:2] < (3, 6),
+                 "RelStorage+sqlite only available on Python 3.6+")
 class Python3RelStorageHPTests(RelStorageHPMixin, Python3Tests):
     pass


### PR DESCRIPTION
Fixes #30.

- Refactor the tests to use a mixin class that defines the methods to create and cleanup storages.
- Use unittest.skip decotarors instead of manually listing out the tests to run in test_suite(). This is simpler now that there are more test classes.
- Add tests for history-free and history-preserving RelStorage storages. History preserving is tested locally, but will be skipped on CI because I haven't released RelStorage 3.3 yet.
- Fix a test hygiene issue that caused subsequent tests to fail after test_skipped_types_are_left_untouched was run.