### PR TITLE
ZODBReference is now callable to fix an unpickling error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 1.6 (unreleased)
 ----------------
 
+- ZODBReference is now callable to fix an unpickling error.
+  (`#20 <https://github.com/zopefoundation/zodbupdate/issues/20>`__)
+
 - Test with history-free and history-preserving RelStorage. Note that
   history-preserving RelStorage requires RelStorage 3.3 or above, and
   Python 2.7 or Python 3.6 and above.

--- a/src/zodbupdate/serialize.py
+++ b/src/zodbupdate/serialize.py
@@ -133,6 +133,11 @@ class ZODBReference(object):
     def __init__(self, ref):
         self.ref = ref
 
+    def __call__(self):
+        """ We need an empty __call__
+        """
+        pass
+
 
 class ObjectRenamer(object):
     """This load and save a ZODB record, modifying all references to


### PR DESCRIPTION
Fixes #20