### PR TITLE
Fix tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes
 2.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix tests by declaring a dependency which is used in ``relstorage 4.0.0`` but
+  not declared.
 
 
 2.0 (2023-02-09)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ tests_require = [
     'persistent',
     'zope.interface',
     'relstorage',
+    'six',  # not declared but used by relstorage 4.0.0
 ]
 
 setup(name='zodbupdate',


### PR DESCRIPTION
By declaring a dependency which is used in `relstorage 4.0.0` but not declared.